### PR TITLE
feat: add `installDependencies` context function

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "commit": "git-cz"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^26.0.0",
     "@types/node-fetch": "^2.5.7",
@@ -60,6 +61,7 @@
     "@poppinss/prompts": "^1.1.0",
     "@poppinss/utils": "^2.2.6",
     "@supportjs/text": "^1.5.1",
+    "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.1",
     "inversify": "^5.0.1",

--- a/src/Appliers/PresetApplier.ts
+++ b/src/Appliers/PresetApplier.ts
@@ -46,7 +46,7 @@ export class PresetApplier implements ApplierContract {
     }
 
     // Apply "before"" execution hook
-    this.applyHook('before', context);
+    await this.applyHook('before', context);
 
     // Ensure we have actions
     if (!context.generator.actions || typeof context.generator.actions !== 'function') {
@@ -56,7 +56,7 @@ export class PresetApplier implements ApplierContract {
     }
 
     // Apply "after" execution hook
-    this.applyHook('after', context);
+    await this.applyHook('after', context);
 
     // Log a success message
     Log.success(`Applied preset ${Color.preset(context.presetName)}.`);
@@ -177,11 +177,9 @@ export class PresetApplier implements ApplierContract {
     }
 
     try {
-      if (false !== (await hook(context))) {
-        return true;
-      }
+      await hook(context);
     } catch (error) {
-      Log.warn(`${Color.keyword(id)} execution hook failed to execute.`);
+      Log.warn(`Hook ${Color.keyword(id)} failed to execute.`);
       Log.debug(error);
     }
 

--- a/src/Contracts/ContextContract.ts
+++ b/src/Contracts/ContextContract.ts
@@ -76,4 +76,9 @@ export interface ContextContract {
      */
     context: SimpleGit;
   };
+
+  /**
+   * Runs `yarn install` if available, or `npm install` if not.
+   */
+  installDependencies: Function;
 }

--- a/src/Importers/EvalImporter.ts
+++ b/src/Importers/EvalImporter.ts
@@ -30,6 +30,7 @@ export class EvalImporter implements ImporterContract {
     'debug',
     'graceful-fs',
     'run-parallel',
+    'cross-spawn',
   ];
 
   async import(filePath: string): Promise<false | GeneratorContract> {

--- a/src/Parsers/GeneratorParser.ts
+++ b/src/Parsers/GeneratorParser.ts
@@ -12,6 +12,7 @@ import { Binding } from '@/Container';
 import fs from 'fs-extra';
 import path from 'path';
 import simpleGit from 'simple-git';
+import { installDependencies } from '@/utils';
 
 /**
  * Parses a preset that should have at least a "preset.js" file, or
@@ -148,6 +149,7 @@ export class GeneratorParser implements ParserContract {
         context: simpleGit(process.cwd()),
         config: (await simpleGit().listConfig()).all,
       },
+      installDependencies: () => installDependencies(targetDirectory),
     };
 
     const parsed = this.parseArgumentsAndFlags(context);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,11 @@
 import { GeneratorContract } from './Contracts';
 import { Logger } from '@poppinss/fancy-logs';
 import { Colors } from '@poppinss/colors';
+import { Prompt as BasePrompt } from '@poppinss/prompts';
 
 export const Color = new Colors();
 export const Log = new Logger();
+export const Prompt = new BasePrompt();
 export const Preset = {
   make: (preset: GeneratorContract) => preset as GeneratorContract,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,39 @@
+import { Log, Color } from '@/Logger';
+import { Text } from '@supportjs/text';
+import spawn from 'cross-spawn';
+import fs from 'fs-extra';
+import path from 'path';
+
+export async function installDependencies(targetDirectory: string): Promise<boolean> {
+  const packageJson = path.join(targetDirectory, 'package.json');
+  let packageManager = 'npm';
+
+  if (!fs.pathExistsSync(packageJson)) {
+    Log.debug(`No dependency will be installed because there is no ${Color.file('package.json')} file.`);
+    return false;
+  }
+
+  if (spawn.sync('yarn', ['--version']).status === 0) {
+    Log.debug(`${Color.keyword('yarn')} has been found. Using it.`);
+    packageManager = 'yarn';
+  }
+
+  Log.debug(`Spawning ${Color.keyword(packageManager)} into ${Color.directory(targetDirectory)}.`);
+
+  const result = spawn.sync(packageManager, ['install'], {
+    cwd: targetDirectory,
+  });
+
+  if (result.status !== 0) {
+    Log.debug(`It appears that the command has failed.`);
+    const trace = Text.make('Exit code: ')
+      .append(result.status?.toString() ?? '0')
+      .line(Color.error('Error output'))
+      .line(result.stderr.toString())
+      .line(Color.error('Standard output'))
+      .line(result.stdout.toString());
+    Log.debug(trace.str());
+  }
+
+  return true;
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,21 @@
+import { Log } from '@/Logger';
+import { TARGET_DIRECTORY } from './constants';
+import fs from 'fs-extra';
+import path from 'path';
+import { installDependencies } from '@/utils';
+
+afterAll(() => {
+  fs.removeSync(TARGET_DIRECTORY);
+});
+
+it('install dependencies', async () => {
+  const packageFile = path.join(TARGET_DIRECTORY, 'package.json');
+  fs.ensureFileSync(packageFile);
+  fs.writeJsonSync(packageFile, {});
+  Log.fake();
+
+  const result = await installDependencies(TARGET_DIRECTORY, process.cwd());
+
+  expect(result).toBe(true);
+  expect(fs.pathExistsSync(path.join(TARGET_DIRECTORY, 'yarn.lock'))).toBe(true);
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,7 +14,7 @@ it('install dependencies', async () => {
   fs.writeJsonSync(packageFile, {});
   Log.fake();
 
-  const result = await installDependencies(TARGET_DIRECTORY, process.cwd());
+  const result = await installDependencies(TARGET_DIRECTORY);
 
   expect(result).toBe(true);
   expect(fs.pathExistsSync(path.join(TARGET_DIRECTORY, 'yarn.lock'))).toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/cross-spawn@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
+  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fs-extra@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.1.tgz#91c8fc4c51f6d5dbe44c2ca9ab09310bd00c7918"
@@ -1465,7 +1472,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
We can now do `await context.installDependencies()` wherever `context` is available. This method is asynchronous.