### PR TITLE
feat: `install-dependencies` action

### DIFF
--- a/src/CommandLineInterface.ts
+++ b/src/CommandLineInterface.ts
@@ -59,26 +59,21 @@ export class CommandLineInterface {
     const target = path.join(flags.in ?? process.cwd());
     const tasks = await this.applier.run({
       argv: argv.splice(1),
-      debug: !!flags.debug,
+      debug: Boolean(flags.debug),
       resolvable: args.preset,
       in: target,
     });
 
-    let hasError = false;
     try {
       await new Listr(tasks).run();
     } catch (error) {
-      Logger.throw(`Preset could not be applied. Try using --debug for more information.`, error);
-      hasError = true;
+      Logger.cli(`Could not apply the preset. Check the logs in ${Logger.saveToFile()} for more information.`);
+
+      return 1;
     }
 
-    if (hasError) {
-      const file = Logger.saveToFile();
-      Logger.cli(`Could not apply the preset. Check the logs in ${file} for more information.`);
-      return 1;
-    } else if (flags.debug) {
-      const file = Logger.saveToFile();
-      Logger.cli(`Since debug is enabled, a log file has been saved in ${file}.`);
+    if (flags.debug) {
+      Logger.cli(`Since debug is enabled, a log file has been saved in ${Logger.saveToFile()}.`);
     }
 
     return 0;

--- a/src/Container/Binding.ts
+++ b/src/Container/Binding.ts
@@ -23,6 +23,7 @@ const Name = {
   EditHandler: 'edit',
   CustomHandler: 'custom',
   PresetHandler: 'preset',
+  InstallDependenciesHandler: 'install-dependencies',
 };
 
 const Tag = {};

--- a/src/Container/Container.ts
+++ b/src/Container/Container.ts
@@ -24,6 +24,7 @@ import {
 } from '@/Handlers';
 import { Listr } from 'listr2';
 import { Logger } from '@/Logger';
+import { InstallDependenciesActionHandler } from '@/Handlers/InstallDependenciesActionHandler';
 
 /**
  * The application container.
@@ -102,5 +103,9 @@ container
   .bind<ActionHandlerContract<'preset'>>(Binding.Handler)
   .to(PresetActionHandler)
   .whenTargetNamed(Name.PresetHandler);
+container
+  .bind<ActionHandlerContract<'install-dependencies'>>(Binding.Handler)
+  .to(InstallDependenciesActionHandler)
+  .whenTargetNamed(Name.InstallDependenciesHandler);
 
 export { container };

--- a/src/Contracts/ActionHandlerContract.ts
+++ b/src/Contracts/ActionHandlerContract.ts
@@ -6,8 +6,11 @@ import { ListrTask } from 'listr2';
 export interface ActionHandlerContract<T = any> {
   for: T;
   validate(action: Partial<BaseActionContract<T>>): Promise<BaseActionContract<T> | false>;
-  handle(
-    action: BaseActionContract<T>,
-    context: ContextContract
-  ): Promise<boolean | ListrTask<ApplicationContextContract>[]>;
+  handle(action: BaseActionContract<T>, context: ContextContract): Promise<ActionHandlingResult>;
+}
+
+export interface ActionHandlingResult {
+  success: boolean;
+  tasks?: ListrTask<ApplicationContextContract>[];
+  reason?: string;
 }

--- a/src/Contracts/Actions/InstallDependenciesActionContract.ts
+++ b/src/Contracts/Actions/InstallDependenciesActionContract.ts
@@ -1,0 +1,22 @@
+import { BaseActionContract } from './ActionContract';
+
+/**
+ * Install the dependencies for the selected ecosystem.
+ */
+export interface InstallDependenciesActionContract extends BaseActionContract<'install-dependencies'> {
+  /**
+   * The ecosystem against which to install the dependencies.
+   */
+  for: Ecosystem;
+
+  /**
+   * Whether to install or update the dependencies.
+   */
+  mode: InstallationMode;
+}
+
+export const ecosystems = ['node', 'php'] as const;
+export type Ecosystem = typeof ecosystems[number];
+
+export const installationModes = ['install', 'update'] as const;
+export type InstallationMode = typeof installationModes[number];

--- a/src/Contracts/Actions/index.ts
+++ b/src/Contracts/Actions/index.ts
@@ -6,3 +6,4 @@ export * from './PromptActionContract';
 export * from './EditJsonActionContract';
 export * from './EditActionContract';
 export * from './PresetActionContract';
+export * from './InstallDependenciesActionContract';

--- a/src/Contracts/ContextContract.ts
+++ b/src/Contracts/ContextContract.ts
@@ -46,6 +46,11 @@ export interface ContextContract {
   argv: string[];
 
   /**
+   * Whether or not debug mode is enabled.
+   */
+  debug: boolean;
+
+  /**
    * The current task.
    */
   task: ListrTaskWrapper<any, any>;

--- a/src/Handlers/CopyActionHandler.ts
+++ b/src/Handlers/CopyActionHandler.ts
@@ -37,11 +37,13 @@ export class CopyActionHandler implements ActionHandlerContract<'copy'> {
     };
   }
 
-  async handle(action: CopyActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: CopyActionContract, context: ContextContract) {
     const filesCopySuccess = await this.copyFiles(action, context);
     const directoriesCopySuccess = await this.copyDirectories(action, context);
 
-    return filesCopySuccess && directoriesCopySuccess;
+    return {
+      success: filesCopySuccess && directoriesCopySuccess,
+    };
   }
 
   private async copyDirectories(action: CopyActionContract, context: ContextContract): Promise<boolean> {

--- a/src/Handlers/CustomActionHandler.ts
+++ b/src/Handlers/CustomActionHandler.ts
@@ -14,9 +14,11 @@ export class CustomActionHandler implements ActionHandlerContract<'custom'> {
     };
   }
 
-  async handle(action: CustomActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: CustomActionContract, context: ContextContract) {
     try {
-      return false !== (await action.execute(context));
+      return {
+        success: false !== (await action.execute(context)),
+      };
     } catch (error) {
       throw Logger.throw('Custom action failed', error);
     }

--- a/src/Handlers/DeleteActionHandler.ts
+++ b/src/Handlers/DeleteActionHandler.ts
@@ -22,11 +22,11 @@ export class DeleteActionHandler implements ActionHandlerContract<'delete'> {
     };
   }
 
-  async handle(action: DeleteActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: DeleteActionContract, context: ContextContract) {
     const directoriesDeleted = await this.delete('directories', action, context);
     const filesDeleted = await this.delete('files', action, context);
 
-    return directoriesDeleted && filesDeleted;
+    return { success: directoriesDeleted && filesDeleted };
   }
 
   protected async delete(

--- a/src/Handlers/EditActionHandler.ts
+++ b/src/Handlers/EditActionHandler.ts
@@ -24,9 +24,9 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
     };
   }
 
-  async handle(action: EditActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: EditActionContract, context: ContextContract) {
     if (!action.files) {
-      return true;
+      return { success: true };
     }
 
     const entries = await fg(action.files, {
@@ -49,7 +49,7 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
       }
     }
 
-    return true;
+    return { success: true };
   }
 
   /**

--- a/src/Handlers/EditJsonActionHandler.ts
+++ b/src/Handlers/EditJsonActionHandler.ts
@@ -22,9 +22,9 @@ export class EditJsonActionHandler implements ActionHandlerContract<'edit-json'>
     };
   }
 
-  async handle(action: EditJsonActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: EditJsonActionContract, context: ContextContract) {
     if (!action.file) {
-      return true;
+      return { success: true };
     }
 
     if (!Array.isArray(action.file)) {
@@ -61,7 +61,7 @@ export class EditJsonActionHandler implements ActionHandlerContract<'edit-json'>
       }
     }
 
-    return true;
+    return { success: true };
   }
 
   protected async delete(original: JsonEntry, data: string | string[]): Promise<JsonEntry> {

--- a/src/Handlers/InstallDependenciesActionHandler.ts
+++ b/src/Handlers/InstallDependenciesActionHandler.ts
@@ -1,0 +1,152 @@
+import { injectable } from 'inversify';
+import {
+  ActionHandlerContract,
+  ContextContract,
+  InstallDependenciesActionContract,
+  ecosystems,
+  installationModes,
+  InstallationMode,
+  Ecosystem,
+  ActionHandlingResult,
+} from '@/Contracts';
+import { Logger } from '@/Logger';
+import { Text } from '@supportjs/text';
+import fs from 'fs-extra';
+import path from 'path';
+import spawn from 'cross-spawn';
+import { ChildProcess } from 'child_process';
+
+@injectable()
+export class InstallDependenciesActionHandler implements ActionHandlerContract<'install-dependencies'> {
+  for = 'install-dependencies' as const;
+
+  async validate(action: Partial<InstallDependenciesActionContract>): Promise<InstallDependenciesActionContract> {
+    if (!action.for) {
+      throw Logger.throw(`No ecosystem specified`);
+    }
+
+    if (!action.mode) {
+      Logger.info('No installation mode specified, defaulting to install.');
+      action.mode = 'install';
+    }
+
+    if (!ecosystems.includes(action.for)) {
+      throw Logger.throw(`Unknown ecosystem "${action.for}"`);
+    }
+
+    if (!installationModes.includes(action.mode)) {
+      throw Logger.throw(`Unknown installation mode "${action.for}"`);
+    }
+
+    return <InstallDependenciesActionContract>{
+      ...action,
+      type: 'install-dependencies',
+    };
+  }
+
+  async handle(action: InstallDependenciesActionContract, context: ContextContract): Promise<ActionHandlingResult> {
+    try {
+      const installs: { [key in Ecosystem]: Function } = {
+        node: this.node,
+        php: this.php,
+      };
+
+      return installs[action.for].call(this, action.mode, context);
+    } catch (error) {
+      throw Logger.throw('Custom action failed', error);
+    }
+  }
+
+  async php(mode: InstallationMode, { targetDirectory }: ContextContract): Promise<ActionHandlingResult> {
+    Logger.info(`Installing PHP dependencies.`);
+
+    const composerJson = path.join(targetDirectory, 'composer.json');
+
+    if (!fs.pathExistsSync(composerJson)) {
+      Logger.info(`composer.json could not be found. Stopping.`);
+
+      return {
+        success: false,
+        reason: 'No composer.json file',
+      };
+    }
+
+    const parameters: string[] = [mode];
+    const packageManager = 'composer';
+
+    Logger.info(`Running: ${packageManager} ${parameters.join(' ')}`);
+
+    const process = spawn(packageManager, parameters, {
+      cwd: targetDirectory,
+    });
+
+    return this.promiseFromProcess(process);
+  }
+
+  async node(mode: InstallationMode, { targetDirectory }: ContextContract): Promise<ActionHandlingResult> {
+    Logger.info(`Installing Node dependencies.`);
+
+    const packageJson = path.join(targetDirectory, 'package.json');
+    let packageManager = 'npm';
+
+    if (!fs.pathExistsSync(packageJson)) {
+      Logger.info(`package.json could not be found. Stopping.`);
+
+      return {
+        success: false,
+        reason: 'No package.json file',
+      };
+    }
+
+    if (spawn.sync('yarn', ['--version']).status === 0) {
+      Logger.info(`${'yarn'} has been found. Using it.`);
+      packageManager = 'yarn';
+    }
+
+    Logger.info(`Spawning ${packageManager} into ${targetDirectory}.`);
+
+    const parameters = ['--verbose'];
+
+    if (mode === 'install') {
+      parameters.push('install');
+    }
+
+    if (packageManager === 'yarn' && mode === 'update') {
+      parameters.push('upgrade');
+    }
+
+    if (packageManager === 'npm' && mode === 'update') {
+      parameters.push('update');
+    }
+
+    Logger.info(`Running: ${packageManager} ${parameters.join(' ')}`);
+
+    const process = spawn(packageManager, parameters, {
+      cwd: targetDirectory,
+    });
+
+    return this.promiseFromProcess(process);
+  }
+
+  protected promiseFromProcess(process: ChildProcess): Promise<ActionHandlingResult> {
+    return new Promise((resolve, reject) => {
+      process.stdout!.on('data', message => {
+        Logger.info(Text.make(message).beforeLast('\n').str());
+      });
+
+      process.stderr!.on('data', message => {
+        Logger.info(Text.make(message).beforeLast('\n').str());
+      });
+
+      process.on('error', error => {
+        Logger.error(error);
+        reject(error);
+      });
+
+      process.on('close', code => {
+        Logger.info(`Command terminated with code ${code}`);
+        resolve({ success: code === 0 });
+      });
+    });
+  }
+}

--- a/src/Handlers/PresetActionHandler.ts
+++ b/src/Handlers/PresetActionHandler.ts
@@ -37,11 +37,15 @@ export class PresetActionHandler implements ActionHandlerContract<'preset'> {
         (action.arguments as string[]).push(...context.argv);
       }
 
-      return await this.applier.run({
-        resolvable: action.preset,
-        argv: action.arguments as string[],
-        in: context.targetDirectory,
-      });
+      return {
+        success: true,
+        tasks: await this.applier.run({
+          resolvable: action.preset,
+          argv: action.arguments as string[],
+          in: context.targetDirectory,
+          debug: context.debug,
+        }),
+      };
     } catch (error) {
       throw Logger.throw(`Preset ${action.preset ?? 'unnamed'} could not be applied.`, error);
     }

--- a/src/Handlers/PromptActionHandler.ts
+++ b/src/Handlers/PromptActionHandler.ts
@@ -14,9 +14,9 @@ export class PromptActionHandler implements ActionHandlerContract<'prompt'> {
     };
   }
 
-  async handle(action: PromptActionContract, context: ContextContract): Promise<boolean> {
+  async handle(action: PromptActionContract, context: ContextContract) {
     if (!action.prompts) {
-      return true;
+      return { success: true };
     }
 
     const prompts = Array.isArray(action.prompts) ? action.prompts : [action.prompts];
@@ -29,6 +29,6 @@ export class PromptActionHandler implements ActionHandlerContract<'prompt'> {
       context.prompts[prompt.name] = await context.task.prompt(prompt);
     }
 
-    return true;
+    return { success: true };
   }
 }

--- a/src/Parsers/GeneratorParser.ts
+++ b/src/Parsers/GeneratorParser.ts
@@ -126,6 +126,7 @@ export class GeneratorParser implements ParserContract {
     Logger.info(`Generating context.`);
     const context: ContextContract = {
       generator,
+      debug: Boolean(parserContext.applierOptions?.debug),
       targetDirectory,
       task: parserContext.task!,
       argv: parserContext?.applierOptions?.argv ?? [],

--- a/test/handlers/copy.test.ts
+++ b/test/handlers/copy.test.ts
@@ -60,7 +60,7 @@ describe('Handler', () => {
   }
 
   it('copies everything in a folder with a glob', async () => {
-    const success = await handleCopy({
+    const { success } = await handleCopy({
       files: '**/*',
       target: '',
     });
@@ -71,7 +71,7 @@ describe('Handler', () => {
   });
 
   it('copies a specific file in a specific folder', async () => {
-    const success = await handleCopy({
+    const { success } = await handleCopy({
       files: 'sub/world.txt',
       target: 'first-subfolder',
     });
@@ -168,7 +168,7 @@ describe('Handler', () => {
   });
 
   it('copies a map of directories to their targets', async () => {
-    const success = await handleCopy(
+    const { success } = await handleCopy(
       {
         directories: {
           sub1: 'root1',
@@ -191,7 +191,7 @@ describe('Handler', () => {
     const action = await validate<CopyActionContract>('copy', {
       type: 'copy',
     });
-    const success = await handleCopy(action as CopyActionContract, {
+    const { success } = await handleCopy(action as CopyActionContract, {
       presetTemplates: templates.COPY_WITH_SUBFOLDERS,
     });
 

--- a/test/handlers/handlers.test.ts
+++ b/test/handlers/handlers.test.ts
@@ -43,6 +43,7 @@ it('finds each handler in the container', () => {
     Name.CustomHandler,
     Name.EditHandler,
     Name.PresetHandler,
+    Name.InstallDependenciesHandler,
   ];
 
   types.forEach(type => {

--- a/test/handlers/preset.test.ts
+++ b/test/handlers/preset.test.ts
@@ -10,7 +10,7 @@ beforeAll(() => fs.removeSync(TARGET_DIRECTORY));
 afterEach(() => fs.removeSync(TARGET_DIRECTORY));
 
 it('installs an external preset', async () => {
-  const tasks = await handle<PresetActionContract>(
+  const { tasks } = await handle<PresetActionContract>(
     Name.PresetHandler,
     {
       preset: stubs.COPY_SINGLE_FILE,
@@ -27,7 +27,7 @@ it('installs an external preset', async () => {
 });
 
 it('handles command line arguments', async () => {
-  const tasks = await handle<PresetActionContract>(
+  const { tasks } = await handle<PresetActionContract>(
     Name.PresetHandler,
     {
       preset: stubs.COPY_SINGLE_FILE,
@@ -45,7 +45,7 @@ it('handles command line arguments', async () => {
 });
 
 it('inherits command line arguments', async () => {
-  const tasks = await handle<PresetActionContract>(
+  const { tasks } = await handle<PresetActionContract>(
     Name.PresetHandler,
     {
       preset: stubs.COPY_SINGLE_FILE,
@@ -64,7 +64,7 @@ it('inherits command line arguments', async () => {
 });
 
 it('does not inherit command line arguments if told so', async () => {
-  const tasks = await handle<PresetActionContract>(
+  const { tasks } = await handle<PresetActionContract>(
     Name.PresetHandler,
     {
       preset: stubs.COPY_SINGLE_FILE,

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -24,9 +24,9 @@ it('apply every hook in the right order', async () => {
           async validate(action: any): Promise<any> {
             return action;
           }
-          async handle(action: any): Promise<boolean> {
+          async handle(action: any) {
             logs.push(`copy ${action.files}`);
-            return true;
+            return { success: true };
           }
         }
       )


### PR DESCRIPTION
Adds a new `install-dependencies` action. It closes #31.

```js
module.exports = {
  actions: () => [{
    type: 'install-dependencies',
    mode: 'install', // and 'update'
    for: 'node' // and 'php'
  }]
}
```