### PR TITLE
feat: handle mono-repositories

### DIFF
--- a/src/Preset.ts
+++ b/src/Preset.ts
@@ -326,6 +326,7 @@ class PendingCopy extends PendingObject {
 class PendingDependencyInstallation extends PendingObject {
   private ecosystem?: Ecosystem;
   private mode?: InstallationMode;
+  private ask: boolean = true;
 
   for(ecosystem: Ecosystem): this {
     this.ecosystem = ecosystem;
@@ -337,12 +338,18 @@ class PendingDependencyInstallation extends PendingObject {
     return this;
   }
 
+  withoutAsking(): this {
+    this.ask = false;
+    return this;
+  }
+
   chain(): Preset {
     return this.preset.addAction({
       type: 'install-dependencies',
       ...this.keys,
       for: this.ecosystem,
       mode: this.mode,
+      ask: this.ask,
     });
   }
 }

--- a/src/Resolvers/GitResolver.ts
+++ b/src/Resolvers/GitResolver.ts
@@ -4,31 +4,64 @@ import { Logger } from '@/Logger';
 import { Name } from '@/Container';
 import git from 'simple-git';
 import tmp from 'tmp';
+import path from 'path';
+
+export interface GitResolverResult {
+  organization: string;
+  repository: string;
+  path: string;
+}
 
 /**
  * A resolver that clones a git repository and returns its local, temporary path.
  */
 @injectable()
 export class GitResolver implements ResolverContract {
+  public readonly urlRegex = /^(?:(?:https:\/\/)|(?:git@))(?:[\w\.]+)[\/|:]([\w-]+)\/([\w-]+)(?:\.git)?(?:\:([\w-\/]+))?$/;
   public readonly name: string = Name.GitResolver;
   public readonly prefix: string = 'git::';
 
   async resolve(input: string): Promise<ResolverResultContract> {
     if (!input.startsWith(this.prefix)) {
-      return {
-        success: false,
-      };
+      return { success: false };
     }
 
     const repositoryUrl = input.substr(this.prefix.length);
+    const data = this.resolveUrlSyntax(repositoryUrl);
 
-    return this.clone(repositoryUrl);
+    if (!data) {
+      Logger.info(`Received the git prefix, but the URL after was not valid.`);
+      return { success: false };
+    }
+
+    return this.clone(data);
+  }
+
+  protected resolveUrlSyntax(input: string): GitResolverResult | false {
+    Logger.info(`Trying to resolve the full url syntax.`);
+    const [matches, organization, repository, path] = input.match(this.urlRegex) ?? [];
+
+    if (!matches) {
+      return false;
+    }
+
+    return {
+      organization,
+      repository,
+      path: path ?? '/',
+    };
+  }
+
+  protected getRepositoryUrl({ organization, repository }: GitResolverResult): string {
+    return `git@github.com:${organization}/${repository}.git`;
   }
 
   /**
    * Clones the given repository.
    */
-  protected async clone(repositoryUrl: string): Promise<ResolverResultContract> {
+  protected async clone(repositoryData: GitResolverResult): Promise<ResolverResultContract> {
+    const repositoryUrl = this.getRepositoryUrl(repositoryData);
+
     try {
       Logger.info(`Generating temporary directory to clone ${repositoryUrl} into.`);
       const temporary = tmp.dirSync();
@@ -40,7 +73,7 @@ export class GitResolver implements ResolverContract {
 
       return {
         success: true,
-        path: temporary.name,
+        path: path.join(temporary.name, repositoryData.path),
         temporary: true,
       };
     } catch (error) {

--- a/src/Resolvers/GitResolver.ts
+++ b/src/Resolvers/GitResolver.ts
@@ -53,7 +53,7 @@ export class GitResolver implements ResolverContract {
   }
 
   protected getRepositoryUrl({ organization, repository }: GitResolverResult): string {
-    return `git@github.com:${organization}/${repository}.git`;
+    return `git://github.com/${organization}/${repository}.git`;
   }
 
   /**

--- a/src/Resolvers/GithubResolver.ts
+++ b/src/Resolvers/GithubResolver.ts
@@ -1,33 +1,54 @@
 import { injectable } from 'inversify';
 import { ResolverResultContract } from '@/Contracts';
-import { GitResolver } from './GitResolver';
+import { GitResolver, GitResolverResult } from './GitResolver';
 import { Name } from '@/Container';
+import { Logger } from '@/Logger';
 
 /**
  * A resolver that clones a Github repository and returns its local, temporary path.
  */
 @injectable()
 export class GithubResolver extends GitResolver {
+  public readonly urlRegex = /^(?:(?:https:\/\/)|(?:git@))(?:(?:www\.)?github\.com)[\/|:]([\w-]+)\/([\w-]+)(?:\.git)?(?:\:([\w-\/]+))?$/;
   public readonly name: string = Name.GithubResolver;
 
   async resolve(input: string): Promise<ResolverResultContract> {
-    const [matches, org, name] =
-      input.match(
-        /^(?:(?:(?:https?|git)(?:@|\:\/\/)(?:www\.)?github\.com(?::|\/))?(?:([\w-]+)\/)?([\w-]+))(?:\.git)?$/
-      ) ?? [];
+    const data = this.resolveUsePreset(input) || this.resolveShortSyntax(input) || this.resolveUrlSyntax(input);
 
-    if (!matches) {
-      return {
-        success: false,
-      };
+    if (!data) {
+      return { success: false };
     }
 
-    const repositoryUrl = this.getRepositoryUrl(org ?? 'use-preset', name);
-
-    return this.clone(repositoryUrl);
+    return this.clone(data);
   }
 
-  private getRepositoryUrl(organizationOrUser: string, repository: string): string {
-    return `git://github.com/${organizationOrUser}/${repository}.git`;
+  resolveUsePreset(input: string): GitResolverResult | false {
+    Logger.info(`Trying to resolve the use-preset short syntax.`);
+    const [matches, repository, path] = input.match(/^([\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
+
+    if (!matches) {
+      return false;
+    }
+
+    return {
+      organization: 'use-preset',
+      repository,
+      path: path ?? '/',
+    };
+  }
+
+  resolveShortSyntax(input: string): GitResolverResult | false {
+    Logger.info(`Trying to resolve the GitHub short syntax.`);
+    const [matches, organization, repository, path] = input.match(/^([\w-]+)\/([\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
+
+    if (!matches) {
+      return false;
+    }
+
+    return {
+      organization,
+      repository,
+      path: path ?? '/',
+    };
   }
 }


### PR DESCRIPTION
This PR implements #34. It allows to have a mono-repository setup, where presets can be in any subfolder of the repository. 

```
innocenzi/laravel/
├── tall/
└── tailwindcss/
    ├── theming/
    └── ui/
```

The above mono-repository setup has two presets, `tall` and `tailwindcss`. To install one of them, you can do `npx use-preset innocenzi/laravel:tall`. 

Subfolders can also be nested: `npx use-preset innocenzi/laravel:tailwindcss/theming`.
