### PR TITLE
refactor: fix issues and minor improvements

### DIFF
--- a/src/Contracts/Actions/CopyActionContract.ts
+++ b/src/Contracts/Actions/CopyActionContract.ts
@@ -1,5 +1,6 @@
 import { BaseActionContract } from './ActionContract';
-import { ContextAware } from '../GeneratorContract';
+
+export type DirectoryCopyObject = string | string[] | { [source: string]: string };
 
 export interface CopyActionContract extends BaseActionContract<'copy'> {
   /**
@@ -12,12 +13,7 @@ export interface CopyActionContract extends BaseActionContract<'copy'> {
    * One or more paths to directories to be recursively copied to the target directory.
    * If an object is given, its keys will be used as the source and its values will be used as the targets.
    */
-  directories:
-    | string
-    | string[]
-    | {
-        [source: string]: string;
-      };
+  directories: DirectoryCopyObject;
 
   /**
    * A path relative to the target directory of where the preset will be applied.

--- a/src/Contracts/Actions/EditActionContract.ts
+++ b/src/Contracts/Actions/EditActionContract.ts
@@ -67,6 +67,6 @@ export interface RemoveLineObject extends SearchableObject {
   after?: number;
 }
 
-export type Replacer = string | ((substring: string, ...args: any[]) => string);
+export type Replacer = string | { replacer: (substring: string, ...args: any[]) => string };
 export type Searchable = string | RegExp;
 export type SearchableFunction = (content: string, context: ContextContract) => Promise<Searchable>;

--- a/src/Handlers/CopyActionHandler.ts
+++ b/src/Handlers/CopyActionHandler.ts
@@ -2,6 +2,7 @@ import { injectable } from 'inversify';
 import { ActionHandlerContract, CopyActionContract, copyConflictStrategies, ContextContract } from '@/Contracts';
 import { contextualize } from '@/Handlers';
 import { Logger } from '@/Logger';
+import { Text } from '@supportjs/text';
 import path from 'path';
 import fg from 'fast-glob';
 import fs from 'fs-extra';
@@ -114,13 +115,20 @@ export class CopyActionHandler implements ActionHandlerContract<'copy'> {
 
     // TODO - refactor to avoid repetition with copyFiles
     // For each found entry, copy according to the strategy.
-    for (const entry of entries) {
+    for (let entry of entries) {
       const input = path.join(context.presetTemplates, from, entry);
       const outputDirectory = path.join(context.targetDirectory, to);
-      const output = path.join(
-        outputDirectory,
-        entry.endsWith('.dotfile') ? `.${entry.replace('.dotfile', '')}` : entry
-      );
+
+      if (entry.endsWith('.dotfile')) {
+        entry = Text.make(entry)
+          .afterLast('/')
+          .prepend('.')
+          .beforeLast('.dotfile')
+          .prepend(Text.make(entry).beforeLast('/').append('/'))
+          .str();
+      }
+
+      const output = path.join(outputDirectory, entry);
 
       // Make sure the output directory exists.
       fs.ensureDirSync(outputDirectory);

--- a/src/Handlers/CopyActionHandler.ts
+++ b/src/Handlers/CopyActionHandler.ts
@@ -120,12 +120,19 @@ export class CopyActionHandler implements ActionHandlerContract<'copy'> {
       const outputDirectory = path.join(context.targetDirectory, to);
 
       if (entry.endsWith('.dotfile')) {
-        entry = Text.make(entry)
-          .afterLast('/')
-          .prepend('.')
-          .beforeLast('.dotfile')
-          .prepend(Text.make(entry).beforeLast('/').append('/'))
-          .str();
+        if (entry.includes('/')) {
+          entry = Text.make(entry)
+            .afterLast('/')
+            .prepend('.')
+            .beforeLast('.dotfile')
+            .prepend(Text.make(entry).beforeLast('/').append('/'))
+            .str();
+        } else {
+          entry = Text.make(entry) //
+            .prepend('.')
+            .beforeLast('.dotfile')
+            .str();
+        }
       }
 
       const output = path.join(outputDirectory, entry);

--- a/src/Handlers/EditActionHandler.ts
+++ b/src/Handlers/EditActionHandler.ts
@@ -35,6 +35,7 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
     const entries = await fg(action.files, {
       dot: true,
       cwd: context.targetDirectory,
+      ignore: ['package-lock.json', 'yarn.lock', 'node_modules'],
     });
 
     Logger.info(`Editing ${entries.length} file(s).`);

--- a/src/Handlers/EditActionHandler.ts
+++ b/src/Handlers/EditActionHandler.ts
@@ -186,6 +186,10 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
         replacement.search = await replacement.search(content, context);
       }
 
+      if (typeof replacement.with !== 'string' && Reflect.has(replacement.with!, 'replacer')) {
+        replacement.with = (replacement.with.replacer as unknown) as string;
+      }
+
       content = content.replace(replacement.search, replacement.with as string);
     } catch (error) {
       throw Logger.throw(`Could not perform string replacement`, error);

--- a/src/Handlers/EditActionHandler.ts
+++ b/src/Handlers/EditActionHandler.ts
@@ -19,6 +19,7 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
 
   async validate(action: Partial<EditActionContract>, context: ContextContract): Promise<EditActionContract> {
     action = contextualize(action, context);
+
     return {
       ...action,
       files: action.files ?? false,
@@ -177,6 +178,8 @@ export class EditActionHandler implements ActionHandlerContract<'edit'> {
     replacement: ReplaceObject,
     context: ContextContract
   ): Promise<string> {
+    replacement = contextualize(replacement, context);
+
     try {
       if (typeof replacement.search === 'function') {
         replacement.search = await replacement.search(content, context);

--- a/src/Preset.ts
+++ b/src/Preset.ts
@@ -26,7 +26,7 @@ export class Preset {
   public beforeEachHook?: HookFunction;
   public afterHook?: HookFunction;
   public afterEachHook?: HookFunction;
-  public parseObject?: ParseObject;
+  public parseObject?: ContextAware<ParseObject>;
 
   public static make(generator: GeneratorContract): GeneratorContract;
   public static make(name: string): Preset;
@@ -70,6 +70,12 @@ export class Preset {
 
   public afterEach(hook: HookFunction): this {
     this.afterEachHook = hook;
+
+    return this;
+  }
+
+  public parse(parseObject: ContextAware<ParseObject>): this {
+    this.parseObject = parseObject;
 
     return this;
   }

--- a/src/Preset.ts
+++ b/src/Preset.ts
@@ -330,7 +330,7 @@ class PendingCopy extends PendingObject {
 }
 
 class PendingDependencyInstallation extends PendingObject {
-  private ecosystem?: Ecosystem;
+  private ecosystem: Ecosystem = 'node';
   private mode?: InstallationMode;
   private ask: boolean = true;
 

--- a/src/Resolvers/GithubResolver.ts
+++ b/src/Resolvers/GithubResolver.ts
@@ -24,7 +24,7 @@ export class GithubResolver extends GitResolver {
 
   resolveUsePreset(input: string): GitResolverResult | false {
     Logger.info(`Trying to resolve the use-preset short syntax.`);
-    const [matches, repository, path] = input.match(/^([\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
+    const [matches, repository, path] = input.match(/^([a-zA-Z][\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
 
     if (!matches) {
       return false;
@@ -39,14 +39,14 @@ export class GithubResolver extends GitResolver {
 
   resolveShortSyntax(input: string): GitResolverResult | false {
     Logger.info(`Trying to resolve the GitHub short syntax.`);
-    const [matches, organization, repository, path] = input.match(/^([\w-]+)\/([\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
+    const [matches, org, repository, path] = input.match(/^([a-zA-Z][\w-]+)\/([\w-]+)(?:\:+([\w-\/]+))?$/) ?? [];
 
     if (!matches) {
       return false;
     }
 
     return {
-      organization,
+      organization: org,
       repository,
       path: path ?? '/',
     };

--- a/test/handlers/edit.test.ts
+++ b/test/handlers/edit.test.ts
@@ -183,7 +183,7 @@ describe('Replacements', () => {
         replace: [
           {
             search: /^line([0-9])$/gm,
-            with: (match, p1) => match.replace(p1, '-n'),
+            with: { replacer: (match, p1) => match.replace(p1, '-n') },
           },
         ],
       },


### PR DESCRIPTION
- Using a flag won't resolve to the `use-preset` GitHub organization anymore
- `parse` has been added to the fluent API
- `installDependencies` will default to `node`
- Nested `.dotfiles` won't have the wrong path anymore
- `copyTemplates` has been added as a convenience method that copy everything from the templates