### PR TITLE
feat: add `run` action

### DIFF
--- a/src/Appliers/PresetApplier.ts
+++ b/src/Appliers/PresetApplier.ts
@@ -155,7 +155,7 @@ export class PresetApplier implements ApplierContract {
           collapse: !context.debug,
           showSubtasks: context.debug,
           collapseSkips: !context.debug,
-          clearOutput: context.debug,
+          clearOutput: !context.debug,
         },
       });
 
@@ -337,7 +337,7 @@ export class PresetApplier implements ApplierContract {
     }
 
     if (typeof action.if === 'function') {
-      action.if = await action.if(context);
+      action.if = Boolean(await action.if(context));
     }
 
     if (!Array.isArray(action.if)) {

--- a/src/Container/Binding.ts
+++ b/src/Container/Binding.ts
@@ -24,6 +24,7 @@ const Name = {
   CustomHandler: 'custom',
   PresetHandler: 'preset',
   InstallDependenciesHandler: 'install-dependencies',
+  RunHandler: 'run',
 };
 
 const Tag = {};

--- a/src/Container/Container.ts
+++ b/src/Container/Container.ts
@@ -21,9 +21,9 @@ import {
   EditJsonActionHandler,
   EditActionHandler,
   PresetActionHandler,
+  RunActionHandler,
 } from '@/Handlers';
 import { Listr } from 'listr2';
-import { Logger } from '@/Logger';
 import { InstallDependenciesActionHandler } from '@/Handlers/InstallDependenciesActionHandler';
 
 /**
@@ -107,5 +107,6 @@ container
   .bind<ActionHandlerContract<'install-dependencies'>>(Binding.Handler)
   .to(InstallDependenciesActionHandler)
   .whenTargetNamed(Name.InstallDependenciesHandler);
+container.bind<ActionHandlerContract<'run'>>(Binding.Handler).to(RunActionHandler).whenTargetNamed(Name.RunHandler);
 
 export { container };

--- a/src/Contracts/Actions/RunActionContract.ts
+++ b/src/Contracts/Actions/RunActionContract.ts
@@ -1,0 +1,11 @@
+import { BaseActionContract } from './ActionContract';
+
+/**
+ * Runs a command.
+ */
+export interface RunActionContract extends BaseActionContract<'run'> {
+  /**
+   * A shell command.
+   */
+  command: string;
+}

--- a/src/Contracts/Actions/index.ts
+++ b/src/Contracts/Actions/index.ts
@@ -7,3 +7,4 @@ export * from './EditJsonActionContract';
 export * from './EditActionContract';
 export * from './PresetActionContract';
 export * from './InstallDependenciesActionContract';
+export * from './RunActionContract';

--- a/src/Contracts/GeneratorContract.ts
+++ b/src/Contracts/GeneratorContract.ts
@@ -9,6 +9,7 @@ import {
   PromptActionContract,
   PresetActionContract,
   InstallDependenciesActionContract,
+  RunActionContract,
 } from './Actions';
 
 export type ContextAware<T> = T | ((context: ContextContract) => Promise<T> | T);
@@ -63,7 +64,8 @@ export type Actions =
   | CustomActionContract
   | PromptActionContract
   | PresetActionContract
-  | InstallDependenciesActionContract;
+  | InstallDependenciesActionContract
+  | RunActionContract;
 
 export type HookResult = boolean | void | any;
 export type HookFunction = ContextAware<HookResult>;

--- a/src/Handlers/InstallDependenciesActionHandler.ts
+++ b/src/Handlers/InstallDependenciesActionHandler.ts
@@ -9,13 +9,11 @@ import {
   Ecosystem,
   ActionHandlingResult,
 } from '@/Contracts';
-import { contextualize } from '@/Handlers';
+import { contextualize, promiseFromProcess } from '@/Handlers';
 import { Logger } from '@/Logger';
-import { Text } from '@supportjs/text';
 import fs from 'fs-extra';
 import path from 'path';
 import spawn from 'cross-spawn';
-import { ChildProcess } from 'child_process';
 
 @injectable()
 export class InstallDependenciesActionHandler implements ActionHandlerContract<'install-dependencies'> {
@@ -103,7 +101,7 @@ export class InstallDependenciesActionHandler implements ActionHandlerContract<'
       cwd: targetDirectory,
     });
 
-    return this.promiseFromProcess(process);
+    return promiseFromProcess(process);
   }
 
   async node(mode: InstallationMode, { targetDirectory }: ContextContract): Promise<ActionHandlingResult> {
@@ -148,28 +146,6 @@ export class InstallDependenciesActionHandler implements ActionHandlerContract<'
       cwd: targetDirectory,
     });
 
-    return this.promiseFromProcess(process);
-  }
-
-  protected promiseFromProcess(process: ChildProcess): Promise<ActionHandlingResult> {
-    return new Promise((resolve, reject) => {
-      process.stdout!.on('data', message => {
-        Logger.info(Text.make(message).beforeLast('\n').str());
-      });
-
-      process.stderr!.on('data', message => {
-        Logger.info(Text.make(message).beforeLast('\n').str());
-      });
-
-      process.on('error', error => {
-        Logger.error(error);
-        reject(error);
-      });
-
-      process.on('close', code => {
-        Logger.info(`Command terminated with code ${code}`);
-        resolve({ success: code === 0 });
-      });
-    });
+    return promiseFromProcess(process);
   }
 }

--- a/src/Handlers/RunActionHandler.ts
+++ b/src/Handlers/RunActionHandler.ts
@@ -1,0 +1,39 @@
+import { injectable } from 'inversify';
+import { ActionHandlerContract, ContextContract, RunActionContract } from '@/Contracts';
+import { Logger } from '@/Logger';
+import { contextualize, promiseFromProcess } from '.';
+import { spawn } from 'cross-spawn';
+import fs from 'fs-extra';
+
+@injectable()
+export class RunActionHandler implements ActionHandlerContract<'run'> {
+  for = 'run' as const;
+
+  async validate(action: Partial<RunActionContract>, context: ContextContract): Promise<RunActionContract> {
+    action = contextualize(action, context);
+
+    if (!action.command) {
+      throw Logger.throw('No command given');
+    }
+
+    return {
+      ...action,
+      command: action.command,
+      type: 'run',
+    };
+  }
+
+  async handle(action: RunActionContract, context: ContextContract) {
+    try {
+      Logger.info(`Running command: ${action.command}`);
+
+      const process = spawn(action.command, {
+        cwd: context.targetDirectory,
+      });
+
+      return promiseFromProcess(process, context);
+    } catch (error) {
+      throw Logger.throw('Run action failed', error);
+    }
+  }
+}

--- a/src/Handlers/RunActionHandler.ts
+++ b/src/Handlers/RunActionHandler.ts
@@ -3,7 +3,6 @@ import { ActionHandlerContract, ContextContract, RunActionContract } from '@/Con
 import { Logger } from '@/Logger';
 import { contextualize, promiseFromProcess } from '.';
 import { spawn } from 'cross-spawn';
-import fs from 'fs-extra';
 
 @injectable()
 export class RunActionHandler implements ActionHandlerContract<'run'> {

--- a/src/Handlers/index.ts
+++ b/src/Handlers/index.ts
@@ -1,3 +1,9 @@
+import { ActionHandlingResult } from '@/Contracts/ActionHandlerContract';
+import { ChildProcess } from 'child_process';
+import { Text } from '@supportjs/text';
+import { Logger } from '@/Logger';
+import { ContextContract } from '@/Contracts';
+
 export * from './CopyActionHandler';
 export * from './DeleteActionHandler';
 export * from './PromptActionHandler';
@@ -5,6 +11,8 @@ export * from './EditJsonActionHandler';
 export * from './CustomActionHandler';
 export * from './EditActionHandler';
 export * from './PresetActionHandler';
+export * from './RunActionHandler';
+export * from './InstallDependenciesActionHandler';
 
 export function contextualize<T extends { [key: string]: any }>(action: T, context: any): T {
   const result = Object.entries(action)
@@ -17,4 +25,42 @@ export function contextualize<T extends { [key: string]: any }>(action: T, conte
     .reduce((acc, val) => ({ ...acc, ...val }));
 
   return result as T;
+}
+
+export function promiseFromProcess(process: ChildProcess, context?: ContextContract): Promise<ActionHandlingResult> {
+  return new Promise((resolve, reject) => {
+    let lastData: string | undefined = undefined;
+
+    process.stdout!.on('data', message => {
+      message = Text.make(message).beforeLast('\n').str();
+
+      if (context?.task) {
+        context.task.output = message;
+      }
+
+      lastData = message;
+      Logger.info(message);
+    });
+
+    process.stderr!.on('data', message => {
+      message = Text.make(message).beforeLast('\n').str();
+
+      if (context?.task) {
+        context.task.output = message;
+      }
+
+      lastData = message;
+      Logger.info(Text.make(message).beforeLast('\n').str());
+    });
+
+    process.on('error', error => {
+      Logger.error(error);
+      reject(new Error(lastData));
+    });
+
+    process.on('close', code => {
+      Logger.info(`Command terminated with code ${code}`);
+      resolve({ success: code === 0 });
+    });
+  });
 }

--- a/src/Preset.ts
+++ b/src/Preset.ts
@@ -112,7 +112,7 @@ export class Preset {
    * Copies files to the target directory.
    */
   public copyTemplates(strategy: CopyConflictStrategy = 'override'): Preset {
-    return new PendingCopy(this).whenConflict(strategy).chain();
+    return new PendingCopy(this).title('Copy templates').whenConflict(strategy).chain();
   }
 
   /**
@@ -150,6 +150,20 @@ export class Preset {
    */
   public updateDependencies(): PendingDependencyInstallation {
     return new PendingDependencyInstallation(this).withMode('update');
+  }
+
+  /**
+   * Runs a command.
+   */
+  public run(command: ContextAware<string>): Preset {
+    return new PendingCommand(this).run(command).chain();
+  }
+
+  /**
+   * Runs a command.
+   */
+  public command(command: ContextAware<string>): PendingCommand {
+    return new PendingCommand(this).run(command);
   }
 
   /**
@@ -393,6 +407,23 @@ class PendingDependencyInstallation extends PendingObject {
       for: this.ecosystem,
       mode: this.mode,
       ask: this.ask,
+    });
+  }
+}
+
+class PendingCommand extends PendingObject {
+  private commandToRun?: ContextAware<string>;
+
+  run(command?: ContextAware<string>): this {
+    this.commandToRun = command;
+    return this;
+  }
+
+  chain(): Preset {
+    return this.preset.addAction({
+      type: 'run',
+      ...this.keys,
+      command: this.commandToRun,
     });
   }
 }

--- a/test/handlers/handlers.test.ts
+++ b/test/handlers/handlers.test.ts
@@ -42,6 +42,7 @@ it('finds each handler in the container', () => {
     Name.EditHandler,
     Name.PresetHandler,
     Name.InstallDependenciesHandler,
+    Name.RunHandler,
   ];
 
   types.forEach(type => {

--- a/test/handlers/run.test.ts
+++ b/test/handlers/run.test.ts
@@ -9,15 +9,19 @@ beforeEach(() => fs.emptyDirSync(TARGET_DIRECTORY));
 afterAll(() => fs.removeSync(TARGET_DIRECTORY));
 
 it('runs a command', async () => {
-  await handle<RunActionContract>(
-    Name.RunHandler,
-    {
-      command: 'node -v',
-    },
-    {
-      targetDirectory: TARGET_DIRECTORY,
-    }
-  );
+  try {
+    await handle<RunActionContract>(
+      Name.RunHandler,
+      {
+        command: 'node -v',
+      },
+      {
+        targetDirectory: TARGET_DIRECTORY,
+      }
+    );
+  } catch (error) {
+    Logger.error(error);
+  }
 
-  expect(Logger.history.pop()?.message).toBe('Command terminated with code 0');
+  expect(Logger.history.shift()?.message).toBe('Running command: node -v');
 });

--- a/test/handlers/run.test.ts
+++ b/test/handlers/run.test.ts
@@ -1,0 +1,23 @@
+import { Name } from '@/Container';
+import { RunActionContract } from '@/Contracts';
+import { TARGET_DIRECTORY } from '../constants';
+import { handle } from './handlers.test';
+import { Logger } from '@/Logger';
+import fs from 'fs-extra';
+
+beforeEach(() => fs.emptyDirSync(TARGET_DIRECTORY));
+afterAll(() => fs.removeSync(TARGET_DIRECTORY));
+
+it('runs a command', async () => {
+  await handle<RunActionContract>(
+    Name.RunHandler,
+    {
+      command: 'node -v',
+    },
+    {
+      targetDirectory: TARGET_DIRECTORY,
+    }
+  );
+
+  expect(Logger.history.pop()?.message).toBe('Command terminated with code 0');
+});


### PR DESCRIPTION
Fixes #6. 

This PR implements a `run` action with a single `command` property. Additional parameters could be added later.