### PR TITLE
feat: support private repositories

### DIFF
--- a/src/Resolvers/GithubResolver.ts
+++ b/src/Resolvers/GithubResolver.ts
@@ -9,17 +9,23 @@ import { Logger } from '@/Logger';
  */
 @injectable()
 export class GithubResolver extends GitResolver {
-  public readonly urlRegex = /^(?:(?:https:\/\/)|(?:git@))(?:(?:www\.)?github\.com)[\/|:]([\w-]+)\/([\w-]+)(?:\.git)?(?:\:([\w-\/]+))?$/;
+  public readonly urlRegex = /^(?:ssh\:)?(?:(?:https:\/\/)|(?:git@))(?:(?:www\.)?github\.com)[\/|:]([\w-]+)\/([\w-]+)(?:\.git)?(?:\:([\w-\/]+))?$/;
   public readonly name: string = Name.GithubResolver;
 
   async resolve(input: string): Promise<ResolverResultContract> {
+    const ssh = this.hasSsh(input);
+
+    if (ssh) {
+      input = this.withoutSsh(input);
+    }
+
     const data = this.resolveUsePreset(input) || this.resolveShortSyntax(input) || this.resolveUrlSyntax(input);
 
     if (!data) {
       return { success: false };
     }
 
-    return this.clone(data);
+    return this.clone({ ...data, ssh });
   }
 
   resolveUsePreset(input: string): GitResolverResult | false {


### PR DESCRIPTION
This PR adds support for using private presets. It introduces the prefix `ssh:` that forces the usage of the SSH URL, but URLs starting with `git@` won't need it. 

```bash
npx use-preset ssh:user/private-repository
npx use-preset git@github.com:user/private-repository.git
```