### PR TITLE
fix: properly detect empty directories

### DIFF
--- a/src/Configuration/Preset.ts
+++ b/src/Configuration/Preset.ts
@@ -110,7 +110,7 @@ export class Preset<CustomContext = any> implements PresetContract {
    * Checks if the target directory is empty.
    */
   isTargetDirectoryEmpty(): boolean {
-    return fs.readdirSync(path.join(this.targetDirectory, '.git')).length === 0;
+    return fs.readdirSync(path.resolve(this.targetDirectory)).length === 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

Check target directory is empty method incorrect

## Steps to reproduce

1. Make preset with `preset.ts`

```typescript
Preset.execute(
    'composer',
    'create-project',
    'laravel/laravel',
    path.resolve(preset.targetDirectory)
  )
  .withTitle('Create project')
  .ifDirectoryEmpty()
```

2. Run

```bash
mkdir ci-test
apply /path/to/preset ci-test
```

## What is the current bug behavior?

Throw error

```
Error: ENOENT: no such file or directory, scandir '/path/to/ci-test/.git'
```

## What is the expected correct behavior?

Execute composer command to create laravel project

## In this pull request

- [x] Fix checks if the target directory is empty