### PR TITLE
feat: allow presets to import modules

### DIFF
--- a/src/Importer/ModuleImporter.ts
+++ b/src/Importer/ModuleImporter.ts
@@ -1,7 +1,7 @@
 import vm from 'vm';
 import path from 'path';
 import fs from 'fs-extra';
-import { transformSync } from 'esbuild';
+import { buildSync } from 'esbuild';
 import { inject, injectable } from 'inversify';
 import { Binding, Bus, color, ExecutionError, getPackage, ImporterContract, Preset } from '@/exports';
 
@@ -13,10 +13,11 @@ export class ModuleImporter implements ImporterContract {
   async import(directory: string): Promise<Preset> {
     this.bus.debug(`Importing preset at ${color.magenta(directory)}.`);
 
-    const script = fs.readFileSync(this.findConfiguration(directory)).toString();
+    const filename = this.findConfiguration(directory);
+    const script = fs.readFileSync(filename).toString();
     const sanitizedScript = this.removeSelfImportStatement(script);
 
-    return await this.evaluateConfiguration(sanitizedScript);
+    return await this.evaluateConfiguration(sanitizedScript, directory, filename);
   }
 
   /**
@@ -73,20 +74,11 @@ export class ModuleImporter implements ImporterContract {
   /**
    * Evaluates the configuration and returns the preset.
    */
-  protected async evaluateConfiguration(script: string): Promise<Preset> {
+  protected async evaluateConfiguration(script: string, directory: string, filename: string): Promise<Preset> {
     try {
-      const context = vm.createContext({
-        exports: {},
-        require,
-        module,
-        Preset: new Preset(),
-        color,
-      });
+      const context = vm.createContext(this.createContext(directory, filename));
 
-      const { code } = transformSync(script, {
-        loader: 'ts',
-        format: 'cjs',
-      });
+      const code = this.transformScript(script, directory, filename);
       vm.runInContext(code, context);
 
       return context.Preset as Preset;
@@ -115,5 +107,67 @@ export class ModuleImporter implements ImporterContract {
         return true;
       })
       .join('\n');
+  }
+
+  protected transformScript(contents: string, resolveDir: string, sourcefile: string): string {
+    const { outputFiles } = buildSync({
+      stdin: {
+        contents,
+        resolveDir,
+        sourcefile,
+        loader: 'ts',
+      },
+      platform: 'node',
+      format: 'cjs',
+      external: ['apply'],
+      bundle: true,
+      write: false,
+    });
+
+    return outputFiles[0].text;
+  }
+
+  protected createContext(directory: string, filename: string): Record<string, any> {
+    const exports = {};
+    const moduleGlobals = {
+      exports,
+      require,
+      module: {
+        exports,
+        filename,
+        id: filename,
+        path: directory,
+        require: module.require,
+      },
+      __dirname: directory,
+      __filename: filename,
+    };
+
+    const nodeGlobals = {
+      Buffer,
+      clearImmediate,
+      clearInterval,
+      clearTimeout,
+      console,
+      global,
+      process,
+      queueMicrotask,
+      setImmediate,
+      setInterval,
+      setTimeout,
+      TextDecoder: (global as any).TextDecorator,
+      TextEncoder: (global as any).TextEncoder,
+      URL: (global as any).URL,
+      URLSearchParams: (global as any).URLSearchParams,
+      WebAssembly: (global as any).WebAssembly,
+    };
+
+    return {
+      ...moduleGlobals,
+      ...nodeGlobals,
+
+      Preset: new Preset(),
+      color,
+    };
   }
 }


### PR DESCRIPTION
Hello,

Thank you for building this library. The concept is very interesting.

This PR tries to allow more complex presets to be written.

### Motivation

I try to use this project to create a cli which helps my developers scaffoling microservices projects.
In this context, I built a lot of presets to initialize a project, add components, tooling, etc.

In this "kind of" preset collection, we have a lot of shared logic which can be refactored but it's impossible to import a module inside the `vm` environment.

### Solution

I saw that you use `esbuild` to be able to accept TypeScript code so I decided to try using it to bundle imported dependencies.
I also had to create a `vm` context which better emulate node env to allow (simple) external `npm` modules to work.
With some configuration, it works for a lot of simple cases.

So to summarize, this PR:
1. Extends the `vm` context to match more closely to node env
2. Use `esbuild` to bundle dependencies when `import` statement is detected

### Limitations

This implementation has some limitations (less than before but still):
- Many npm modules will not work in a `vm` environment
- Many npm modules are incompatible with `esbuild`

Despite this, it is very useful for local imports and it works with some npm deps.

### Review

If you look at the `createContext` method, I commented some globals that should be available in `node` >= 12 but are not available in TypeScript in the specific configuration of this project.

I see two choices to enable these globals:
1. Include `DOM` lib in `tsconfig.json`, which is not a good thing because it allows other DOM globals to be incorrectly used in the project.
2. Add an ambiant `globals.d.ts` in the project to define missing globals (even as any)

What do you think?