### PR TITLE
fix: missing values in child Preset when using Preset.group()

### DIFF
--- a/src/Handlers/GroupHandler.ts
+++ b/src/Handlers/GroupHandler.ts
@@ -29,6 +29,7 @@ export class GroupHandler implements HandlerContract {
     const preset = new Preset();
     preset.args = action.preset.args;
     preset.options = action.preset.options;
+    preset.context = action.preset.context;
     preset.git = action.preset.git;
     preset.presetDirectory = action.preset.presetDirectory;
     preset.prompts = action.preset.prompts;

--- a/src/Handlers/GroupHandler.ts
+++ b/src/Handlers/GroupHandler.ts
@@ -34,6 +34,7 @@ export class GroupHandler implements HandlerContract {
     preset.presetDirectory = action.preset.presetDirectory;
     preset.prompts = action.preset.prompts;
     preset.templateDirectory = action.preset.templateDirectory;
+    preset.targetDirectory = action.preset.targetDirectory;
     preset.actions = [];
     action.actions.callback(preset);
     preset.actions.map((action) => action.withTitle(false));


### PR DESCRIPTION
### Reproduction

If you try to run the following preset:

```javascript
Preset.hook(preset => {
    preset.context = {
        ...preset.context,
        name: "test"
    };
});

Preset.group((preset) => {
    preset
        .edit("file.js")
        .replaceVariables(({ context }) => ({ name: context.name }));
}).withTitle("initializating file");
```

You will get the following error:
 `TypeError: Cannot read property 'name' of undefined`

### Solution

Pass the parent `context` to the created group `Preset`.

### Update

I found the same issue with `targetDirectory`.