### PR TITLE
fix: error on deleting files.

### DIFF
--- a/src/Handlers/DeleteHandler.ts
+++ b/src/Handlers/DeleteHandler.ts
@@ -20,7 +20,7 @@ export class DeleteHandler implements HandlerContract {
       }
 
       this.bus.debug(`Deleting ${color.magenta(absolutePath)}.`);
-      fs.rmdirSync(absolutePath, {
+      fs.rmSync(absolutePath, {
         recursive: true,
       });
     }


### PR DESCRIPTION
This should fix #74 .

This error happens when you try to delete a file. Example:

```js
Preset.delete(['photo.jpg'])
```

This is because `DeleteHandler` relies on `rmdirSync` to try to delete files or directories. But, according to [nodejs documentation](https://nodejs.org/api/fs.html#fs_fs_rmdirsync_path_options), this method only works to delete directories.

> Using fs.rmdirSync() on a file (not a directory) results in an ENOENT error on Windows and an ENOTDIR error on POSIX.

So, I'm replacing it with the [rmSync](https://nodejs.org/api/fs.html#fs_fs_rmsync_path_options) that can delete either directories or files.