### PR TITLE
fix: change `rmSync` for `removeSync`

### DIFF
--- a/src/Handlers/DeleteHandler.ts
+++ b/src/Handlers/DeleteHandler.ts
@@ -20,9 +20,7 @@ export class DeleteHandler implements HandlerContract {
       }
 
       this.bus.debug(`Deleting ${color.magenta(absolutePath)}.`);
-      fs.rmSync(absolutePath, {
-        recursive: true,
-      });
+      fs.removeSync(absolutePath);
     }
   }
 }


### PR DESCRIPTION
After a quick research, I've figured out that, According to node.js docs, rmSync was added in v14.14.0. So any Node Version running anything older would experience this issue.

Preset.delete() requires node version greater than 14.14.0 in other to function well as DeleteHandler.ts uses fs.rmSync on line 23.

Since you already have fs-extra as a dependency you might prefer using

`fs.removeSync()`

https://github.com/jprichardson/node-fs-extra/blob/master/docs/remove-sync.md 

This fixes Issue #80 