### PR TITLE
docs: fix link to "Preset list"

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -49,7 +49,7 @@ const nav: NavItem[] = [
 		text: 'Ecosystem',
 		items: [
 			{ text: 'Laravel presets', link: 'https://github.com/laravel-presets' },
-			{ text: 'Preset list', link: 'https://github.com/presets/awesome' },
+			{ text: 'Preset list', link: 'https://github.com/preset/awesome' },
 		],
 	},
 ]


### PR DESCRIPTION
@presets seems to be a deprecated org. Fix link to properly go to @preset's repo [awesome](https://github.com/preset/awesome).