### PR TITLE
fix(install-packages): support `yarn`

### DIFF
--- a/packages/core/src/actions/install-packages.ts
+++ b/packages/core/src/actions/install-packages.ts
@@ -1,4 +1,4 @@
-import { debug, execute, wrap, detectNodePackageManager } from '../utils'
+import { debug, execute, wrap, detectNodePackageManager, invoke } from '../utils'
 import { PresetError } from '../errors'
 import { defineAction } from '../api'
 import { config } from '../config'
@@ -32,15 +32,20 @@ async function getNodePackageManagerInstallArguments(cwd: string, options: Insta
 	}
 
 	if (packageManager === 'yarn') {
-		const cmd = (() => 
+		const command = invoke(() => {
+			if (options.type === 'update') {
+				return 'upgrade'
+			}
+
+			if (packageNames.length) {
+				return 'add'
+			}
+
+			return 'install'
+		})
+
 		return [packageManager, [
-			(() => {
-				if (options.type === "install")
-					if (packageNames.length)
-						return "add"
-					return "install"
-				return "upgrade"
-			})(),
+			command,
 			options.dev ? '-D' : '',
 			...args,
 			...packageNames,

--- a/packages/core/src/actions/install-packages.ts
+++ b/packages/core/src/actions/install-packages.ts
@@ -32,8 +32,15 @@ async function getNodePackageManagerInstallArguments(cwd: string, options: Insta
 	}
 
 	if (packageManager === 'yarn') {
+		const cmd = (() => 
 		return [packageManager, [
-			options.type === 'install' ? 'add' : 'upgrade',
+			(() => {
+				if (options.type === "install")
+					if (packageNames.length)
+						return "add"
+					return "install"
+				return "upgrade"
+			})(),
 			options.dev ? '-D' : '',
 			...args,
 			...packageNames,

--- a/packages/core/src/actions/install-packages.ts
+++ b/packages/core/src/actions/install-packages.ts
@@ -33,7 +33,7 @@ async function getNodePackageManagerInstallArguments(cwd: string, options: Insta
 
 	if (packageManager === 'yarn') {
 		return [packageManager, [
-			options.type === 'install' ? 'install' : 'upgrade',
+			options.type === 'install' ? 'add' : 'upgrade',
 			options.dev ? '-D' : '',
 			...args,
 			...packageNames,

--- a/packages/core/test/actions/install-packages.test.ts
+++ b/packages/core/test/actions/install-packages.test.ts
@@ -275,7 +275,7 @@ it('installs existing packages with yarn', async() => await usingSandbox({
 		})
 	},
 	targetStructure: {
-		...emptyPackageJsonStructure, 
+		...emptyPackageJsonStructure,
 		'package.json': { type: 'file', content: '{"dependencies": {"debug": "^4.3.4"}}' },
 	},
 }))

--- a/packages/core/test/actions/install-packages.test.ts
+++ b/packages/core/test/actions/install-packages.test.ts
@@ -1,6 +1,11 @@
 import { it } from 'vitest'
 import { installPackages } from '../../src'
-import { usingSandbox, expectStructureMatches } from '../utils'
+import { usingSandbox, expectStructureMatches, DirectoryStructure } from '../utils'
+
+const emptyPackageJsonStructure: DirectoryStructure = {
+	'package.json': { type: 'file', content: '{}' },
+	'.npmrc': { type: 'file', content: 'shared-workspace-lockfile=false' },
+}
 
 it('installs the given php package', async() => await usingSandbox({
 	fn: async({ targetDirectory }, makeTestPreset) => {
@@ -79,7 +84,7 @@ it('installs the given node package with npm by default', async() => await using
 			},
 		})
 	},
-	targetStructure: { 'package.json': { type: 'file', content: '{}' } }, // necessary so it's not installed in the first package.json directory
+	targetStructure: { 'package.json': { type: 'file', content: '{}' } },
 }))
 
 it('installs the given node package as development dependencies', async() => await usingSandbox({
@@ -108,7 +113,7 @@ it('installs the given node package as development dependencies', async() => awa
 			},
 		})
 	},
-	targetStructure: { 'package.json': { type: 'file', content: '{}' } }, // necessary so it's not installed in the first package.json directory
+	targetStructure: { 'package.json': { type: 'file', content: '{}' } },
 }))
 
 it('installs the given node package with the specified package manager', async() => await usingSandbox({
@@ -136,10 +141,7 @@ it('installs the given node package with the specified package manager', async()
 			},
 		})
 	},
-	targetStructure: {
-		'package.json': { type: 'file', content: '{}' },
-		'.npmrc': { type: 'file', content: 'shared-workspace-lockfile=false' },
-	}, // necessary so it's not installed in the first package.json directory
+	targetStructure: emptyPackageJsonStructure,
 }))
 
 it('installs the given packages at once', async() => await usingSandbox({
@@ -168,7 +170,7 @@ it('installs the given packages at once', async() => await usingSandbox({
 			},
 		})
 	},
-	targetStructure: { 'package.json': { type: 'file', content: '{}' } }, // necessary so it's not installed in the first package.json directory
+	targetStructure: { 'package.json': { type: 'file', content: '{}' } },
 }))
 
 it('installs packages already present in package.json with npm', async() => await usingSandbox({
@@ -225,5 +227,55 @@ it('installs packages already present in composer.json', async() => await usingS
 			type: 'file',
 			json: { require: { 'innocenzi/laravel-vite': '^0.1.20' } },
 		},
+	},
+}))
+
+it('installs the given node package with yarn', async() => await usingSandbox({
+	fn: async({ targetDirectory }, makeTestPreset) => {
+		const { executePreset } = await makeTestPreset({
+			handler: async() => await installPackages({
+				for: 'node',
+				packages: 'debug@^4.3.4',
+				packageManager: 'yarn',
+			}),
+		})
+
+		await executePreset()
+		await expectStructureMatches(targetDirectory, {
+			'node_modules': { type: 'directory' },
+			'node_modules/debug': { type: 'directory' },
+			'yarn.lock': { type: 'file' },
+			'package.json': {
+				type: 'file',
+				json: {
+					dependencies: {
+						debug: '^4.3.4',
+					},
+				},
+			},
+		})
+	},
+	targetStructure: emptyPackageJsonStructure,
+}))
+
+it('installs existing packages with yarn', async() => await usingSandbox({
+	fn: async({ targetDirectory }, makeTestPreset) => {
+		const { executePreset } = await makeTestPreset({
+			handler: async() => await installPackages({
+				for: 'node',
+				packageManager: 'yarn',
+			}),
+		})
+
+		await executePreset()
+		await expectStructureMatches(targetDirectory, {
+			'node_modules': { type: 'directory' },
+			'node_modules/debug': { type: 'directory' },
+			'yarn.lock': { type: 'file' },
+		})
+	},
+	targetStructure: {
+		...emptyPackageJsonStructure, 
+		'package.json': { type: 'file', content: '{"dependencies": {"debug": "^4.3.4"}}' },
 	},
 }))


### PR DESCRIPTION
```
Command failed with exit code 1: yarn install -D @serverless-stack/cli @serverless-stack/resources
      warning package.json: No license field
      error `install` has been replaced with `add` to add new dependencies. Run "yarn add @serverless-stack/cli @serverless-stack/resources --dev" instead.
```